### PR TITLE
Transfer Meier Made Cloudflare ownership

### DIFF
--- a/pulumi/src/cloudflare/record.ts
+++ b/pulumi/src/cloudflare/record.ts
@@ -1,7 +1,7 @@
 import * as cloudflare from '@pulumi/cloudflare'
 import { tunnelHostname } from './tunnel'
 import { provider } from './provider'
-import { andymeierZone, andrewmeierZone, meiermadeZone } from './zone'
+import { andymeierZone, andrewmeierZone } from './zone'
 import * as config from '../config'
 
 export const andymeier = new cloudflare.DnsRecord(config.identifier, {
@@ -28,24 +28,6 @@ new cloudflare.DnsRecord(`${config.identifier}-andrewmeier-root`, {
 new cloudflare.DnsRecord(`${config.identifier}-andrewmeier-www`, {
     name: 'www',
     zoneId: andrewmeierZone.id,
-    type: 'A',
-    content: '192.0.2.1',
-    proxied: true,
-    ttl: 1
-}, { provider })
-
-new cloudflare.DnsRecord(`${config.identifier}-meiermade-root`, {
-    name: '@',
-    zoneId: meiermadeZone.id,
-    type: 'A',
-    content: '192.0.2.1',
-    proxied: true,
-    ttl: 1
-}, { provider })
-
-new cloudflare.DnsRecord(`${config.identifier}-meiermade-www`, {
-    name: 'www',
-    zoneId: meiermadeZone.id,
     type: 'A',
     content: '192.0.2.1',
     proxied: true,

--- a/pulumi/src/cloudflare/redirect.ts
+++ b/pulumi/src/cloudflare/redirect.ts
@@ -1,6 +1,6 @@
 import * as cloudflare from '@pulumi/cloudflare'
 import { provider } from './provider'
-import { andrewmeierZone, meiermadeZone } from './zone'
+import { andrewmeierZone } from './zone'
 import * as config from '../config'
 
 // andrewmeier.dev -> andymeier.dev
@@ -21,30 +21,6 @@ new cloudflare.Ruleset(`${config.identifier}-andrewmeier-redirect`, {
                 preserveQueryString: true,
                 targetUrl: {
                     expression: 'concat("https://andymeier.dev", http.request.uri.path)'
-                }
-            }
-        }
-    }]
-}, { provider })
-
-// meiermade.com -> andymeier.dev/services
-new cloudflare.Ruleset(`${config.identifier}-meiermade-redirect`, {
-    zoneId: meiermadeZone.id,
-    name: 'Redirect meiermade.com to andymeier.dev/services',
-    kind: 'zone',
-    phase: 'http_request_dynamic_redirect',
-    rules: [{
-        ref: 'meiermade_to_andymeier_services',
-        description: 'Redirect meiermade.com and www.meiermade.com to services page',
-        enabled: true,
-        expression: '(http.host eq "meiermade.com") or (http.host eq "www.meiermade.com")',
-        action: 'redirect',
-        actionParameters: {
-            fromValue: {
-                statusCode: 301,
-                preserveQueryString: true,
-                targetUrl: {
-                    value: 'https://andymeier.dev/services'
                 }
             }
         }

--- a/pulumi/src/cloudflare/zone.ts
+++ b/pulumi/src/cloudflare/zone.ts
@@ -14,4 +14,3 @@ const getZone = (name: string) =>
 
 export const andymeierZone = getZone('andymeier.dev')
 export const andrewmeierZone = getZone('andrewmeier.dev')
-export const meiermadeZone = getZone('meiermade.com')


### PR DESCRIPTION
## Summary

- stop the personal-site stack from managing `meiermade.com` DNS records
- stop the personal-site stack from managing the legacy Meier Made redirect ruleset
- leave `andymeier.dev` and `andrewmeier.dev` resources unchanged

The corresponding resources are transferred in Pulumi state to the independent Meier Made stack before merge, so this change does not delete live Cloudflare resources.

## Verification

- `cd pulumi && npm run check`
- `git diff --check`
