### PR TITLE
Fix OpenTelemetry resource attributes

### DIFF
--- a/app/src/App/src/Program.fs
+++ b/app/src/App/src/Program.fs
@@ -42,7 +42,7 @@ let configureLogger (config: Config) =
             .WriteTo.OpenTelemetry(fun opts ->
                 opts.Endpoint <- config.seq.endpoint + "/ingest/otlp/v1/logs"
                 opts.Protocol <- OtlpProtocol.HttpProtobuf
-                opts.ResourceAttributes <- dict [ "service.name", box config.appName ])
+                opts.ResourceAttributes.Add("service.name", box config.appName))
             .CreateLogger()
 
     Log.Logger <- logger

--- a/e2e/scripts/start-local.sh
+++ b/e2e/scripts/start-local.sh
@@ -52,6 +52,8 @@ GOOGLE_ANALYTICS_MEASUREMENT_ID=G-LOCAL \
 NOTION_API_KEY=mock-notion-token \
 NOTION_ARTICLES_DATABASE_ID=mock-articles \
 NOTION_BASE_URL="http://127.0.0.1:${mock_port}/v1" \
+OTEL_RESOURCE_ATTRIBUTES="deployment.environment.name=e2e" \
+OTEL_SERVICE_NAME="andymeier-e2e" \
 SEQ_ENDPOINT="http://127.0.0.1:5341" \
 SERVER_URL="http://127.0.0.1:${server_port}" \
 SQLITE_PATH="$sqlite_path" \


### PR DESCRIPTION
## Summary

- add the service name to the OpenTelemetry sink's existing mutable resource-attribute dictionary
- stop replacing that dictionary with an immutable F# `dict`
- run local E2E with `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` to prevent regression

## Verification

- reproduced the pre-fix `System.NotSupportedException: This value cannot be mutated`
- `cd app && ./fake.sh Test` — 80 passed
- `cd app && ./fake.sh Publish` — passed
- `cd e2e && npx playwright test --project=firefox --retries=0` — 7 passed with OTEL variables present
- explicit startup smoke with both OTEL variables and `/health` — passed
